### PR TITLE
Ajoute la récupération de sauvegardes automatiques

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
+# CMS
+
 CMS intégré aux sites de la manifestation numérique du 10 septembre 2025,
 qui souhaitent personnaliser leur site,
 et qui disposent d'un hébergement avec une base de données.
 
 Documentation dans le [wiki](https://github.com/10s25/cms/wiki).
+
+
+## Docker
+
+Pour développer en local avec docker :
+
+```
+docker compose -f docker-compose-dev.yml up -d
+```
+
+Puis aller dans http://localhost:8880/

--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ Puis aller dans http://localhost:8880/
 ## Partage de la sauvegarde
 
 Copier le fichier `database.php` en prod en modifiant l'en-tête. Les IP autorisées pourront consulter `http://localhost:8880/database.php?token=[access_token]` pour récupérer la base.
+
+
+## Sauvegarde automatique
+
+Installer le module saveauto depuis https://plugins.spip.net/saveauto.html et activer la sauvegarde régulière.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ docker compose -f docker-compose-dev.yml up -d
 ```
 
 Puis aller dans http://localhost:8880/
+
+## Partage de la sauvegarde
+
+Copier le fichier `database.php` en prod en modifiant l'en-tête. Les IP autorisées pourront consulter `http://localhost:8880/database.php?token=[access_token]` pour récupérer la base.

--- a/database.php
+++ b/database.php
@@ -1,0 +1,44 @@
+<?php
+
+// false en développement, true en prod
+$PROD = false;
+// jeton secret à modifier en prod
+$access_token = 'accesstoken'; 
+// mettre la liste d'adresses autorisées en prod
+$allowed_ips = ['192.168.0.1', '127.0.0.1', '172.18.0.1'];
+// chemin de la base de données
+$db_file = 'tmp/dump/Mon_site_SPIP_20250905.sqlite';
+
+// -----
+
+// Empêche l'accès direct via l'URL en prod
+if ($PROD && isset($_SERVER['SCRIPT_FILENAME']) && $_SERVER['SCRIPT_FILENAME'] == __FILE__) {
+    http_response_code(403);
+    die('Accès interdit depuis l\'url.');
+}
+
+// Vérifie l'adresse IP
+if (!in_array($_SERVER['REMOTE_ADDR'], $allowed_ips)) {
+    http_response_code(403);
+    die('Accès non autorisé depuis cette IP : ' . $_SERVER['REMOTE_ADDR'] );
+}
+
+// Vérifie le jeton
+if (!isset($_GET['token']) || $_GET['token'] !== $access_token) {
+    http_response_code(403);
+    die('Accès interdit au jeton.');
+}
+
+// Vérifie l'existance du fichier
+if (!file_exists($db_file)) {
+    http_response_code(404);
+    die('Fichier introuvable.');
+}
+
+// Envoie le fichier
+header('Content-Disposition: attachment; filename="database.sqlite"');
+header('Content-Length: ' . filesize($db_file));
+readfile($db_file);
+
+exit;
+?>

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,25 @@
+services:
+  db:
+    image: mariadb:11.4
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=spip
+      - MYSQL_USER=spip
+      - MYSQL_PASSWORD=spip
+
+  app:
+    image: ipeos/spip:4.4
+    restart: always
+    links:
+      - db:mysql
+    environment:
+      - SPIP_AUTO_INSTALL=1
+      - SPIP_DB_SERVER=mysql
+      - SPIP_DB_LOGIN=spip
+      - SPIP_DB_PASS=spip
+      - SPIP_DB_NAME=spip
+      - SPIP_SITE_ADDRESS=http://localhost:8880
+      - SPIP_ADMIN_PASS=password
+    ports:
+      - 8880:80

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,6 +13,9 @@ services:
     restart: always
     links:
       - db:mysql
+    volumes:
+      # monte les fichiers spip localement
+      - ./html:/var/www/html
     environment:
       - SPIP_AUTO_INSTALL=1
       - SPIP_DB_SERVER=mysql


### PR DESCRIPTION
Installer le plugin spip pour configurer les sauvegardes automatiques, éditer et ajouter le fichier `database.php` pour permettre d'accéder à la dernière sauvegarde depuis une IP autorisée et avec le jeton d'accès.